### PR TITLE
Each randomInstance is now loaded as a command on startup

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -115,7 +115,17 @@ export default class DailyRandomNotePlugin extends Plugin {
 		this.app.workspace.onLayoutReady(async () => {
 			await this.checkTimeAndOpenRandomNotes()
 		});
+
+		// Load each randomInstance as a command on startup 
+		this.settings.randomInstances.forEach(randomInstance => {
+			this.addCommand({
+				id: `Open random note from: ${randomInstance.name}`,
+				name: randomInstance.name,
+				callback: async () => { this.openRandomNoteWithInstance(randomInstance) }
+			});
+		});
 	}
+
 	getDailyRandomNoteResetTime() {
 		let timeSplit = this.settings.nextRandomNotesDay.split("/")
 		let timeToCheck: Date = new Date()
@@ -128,6 +138,7 @@ export default class DailyRandomNotePlugin extends Plugin {
 
 		return timeToCheck
 	}
+
 	async checkTimeAndOpenRandomNotes() {
 		const today = getDayString(new Date())
 


### PR DESCRIPTION
As I use the command palette more often than the ribbon it might be nice to have each random instance be available with it's own command. This is just a quick fix which loads each `randomInstance` as a command on startup. 

This works for me, but to improve this a bit more, it might be nice to register each `randomInstance` once the settings are saved... (I'm not sure how to do that...)